### PR TITLE
some minor improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,9 @@ Passing options
         className : 'my-class-name',
         zIndex: 10,
         mind: '#header',
-        top: 20
+        top: 20,
+        //calcMethod:"default",
+        calcMethod:"jQuery",
     });
     
 Instantiate without jQuery:

--- a/src/fixto.js
+++ b/src/fixto.js
@@ -302,8 +302,8 @@ var fixto = (function ($, window, document) {
             className: 'fixto-fixed',
             top: 0,
             mindViewport: false,
-            calcMethod:"default",
-            //calcMethod:"jQuery",
+            //calcMethod:"default",
+            calcMethod:"jQuery",
         };
         this._setOptions(options);
     }
@@ -429,7 +429,8 @@ var fixto = (function ($, window, document) {
         // at ie8 maybe only in vm window resize event fires everytime an element is resized.
         _toresize : ieversion===8 ? document.documentElement : window,
 
-        _onscroll: function _onscroll() {
+        _onscroll: function _onscroll() {            
+            if(!this._running || !this.parent) return; //we're called either while being disabled or being disposed
             this._scrollTop = document.documentElement.scrollTop || document.body.scrollTop;
             this._parentBottom = (this.parent.offsetHeight + this._fullOffset('offsetTop', this.parent));
 

--- a/src/fixto.js
+++ b/src/fixto.js
@@ -506,7 +506,7 @@ var fixto = (function ($, window, document) {
         },
         // Calculate cumulative offset of the element.
         // Optionally according to context
-        __fullOffset: function _fullOffset(offsetName, elm, context) {
+        __fullOffset: function __fullOffset(offsetName, elm, context) {
             var offset = elm[offsetName];
             var offsetParent = elm.offsetParent;
 

--- a/src/fixto.js
+++ b/src/fixto.js
@@ -488,8 +488,10 @@ var fixto = (function ($, window, document) {
 
             this.child.style.top = (diff + mindTop + top + this.options.top) - computedStyle.toFloat(childStyles.marginTop) + 'px';
         },
-        _fullOffset: function _fullOffset(offsetName, elm, context) {            
-            if(!context && (this.options.calcMethod 
+        _fullOffset: function _fullOffset(offsetName, elm, context) {
+            if(typeof(this.options.calcMethod) == "function"){
+                return this.options.calcMethod.apply(this, arguments);
+            }else if(!context && (this.options.calcMethod 
                 || this.options.calcMethod === "jQuery"
                 || (this.options.calcMethod === "default2" && elm === this.parent))
             ){

--- a/src/fixto.js
+++ b/src/fixto.js
@@ -491,7 +491,7 @@ var fixto = (function ($, window, document) {
         _fullOffset: function _fullOffset(offsetName, elm, context) {
             if(typeof(this.options.calcMethod) == "function"){
                 return this.options.calcMethod.apply(this, arguments);
-            }else if(!context && (this.options.calcMethod 
+            }else if($ && !context && (this.options.calcMethod 
                 || this.options.calcMethod === "jQuery"
                 || (this.options.calcMethod === "default2" && elm === this.parent))
             ){

--- a/src/fixto.js
+++ b/src/fixto.js
@@ -491,7 +491,7 @@ var fixto = (function ($, window, document) {
         _fullOffset: function _fullOffset(offsetName, elm, context) {            
             if(!context && (this.options.calcMethod 
                 || this.options.calcMethod === "jQuery"
-                || (this.options.calcMethod === "default2" && elm != this.parent))
+                || (this.options.calcMethod === "default2" && elm === this.parent))
             ){
                 var offset = $(elm).offset();
                 if(offsetName && offsetName.toLowerCase && offsetName.toLowerCase().indexOf("top")){

--- a/src/fixto.js
+++ b/src/fixto.js
@@ -301,7 +301,9 @@ var fixto = (function ($, window, document) {
         this.options = {
             className: 'fixto-fixed',
             top: 0,
-            mindViewport: false
+            mindViewport: false,
+            calcMethod:"default",
+            //calcMethod:"jQuery",
         };
         this._setOptions(options);
     }
@@ -485,10 +487,23 @@ var fixto = (function ($, window, document) {
 
             this.child.style.top = (diff + mindTop + top + this.options.top) - computedStyle.toFloat(childStyles.marginTop) + 'px';
         },
-
+        _fullOffset: function _fullOffset(offsetName, elm, context) {            
+            if(!context && (this.options.calcMethod 
+                || this.options.calcMethod === "jQuery"
+                || (this.options.calcMethod === "default2" && elm != this.parent))
+            ){
+                var offset = $(elm).offset();
+                if(offsetName && offsetName.toLowerCase && offsetName.toLowerCase().indexOf("top")){
+                    return offset.top;
+                }else{
+                    return offset.left;
+                }
+            }
+            return this.__fullOffset.apply(this, arguments);
+        },
         // Calculate cumulative offset of the element.
         // Optionally according to context
-        _fullOffset: function _fullOffset(offsetName, elm, context) {
+        __fullOffset: function _fullOffset(offsetName, elm, context) {
             var offset = elm[offsetName];
             var offsetParent = elm.offsetParent;
 


### PR DESCRIPTION
Hi,

Thanks for the great work! 
I noticed in some scenario's the _fullOffset doesn't provided the correct value. Currently i made an alternative to jquery or allow to provide a custom implementation to resolve the offset. however others could be added, for example the more performant getBoundingClientRect. 
Also i noticed that after a destroy call, the onscroll handler could still be active after start is called again, in that case the parent is gone, which makes this method throw errors. i made a simple early return for that, so at least error's aren't thrown. of course this is an implementation error, but i believe it should be shielded against it.